### PR TITLE
Adding dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,8 @@ setup(
     description='Commandline interface to HabitRPG (http://habitrpg.com)',
     long_description=readme,
     packages=['hrpg'],
+    install_requires=[
+        'docopt',
+    ],
     scripts=['bin/hrpg'],
 )


### PR DESCRIPTION
Code requires docopt but doesn't specify it. Following http://www.scotttorborg.com/python-packaging/dependencies.html and specifying it in the setup.py
