### PR TITLE
spike netrc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Two tools for interacting with [Habitica](http://habitica.com):
 install
 -------
 
-First `pip install habitica`. Then, using `habiticarc.sample.json` as a
-template, you'll want to add your API credentials to an `~/.habiticarc` file in
+First `pip install habitica`. Then, using `netrc.sample` as a
+template, you'll want to add your API credentials to an `~/.netrc` file in
 your home directory.
 
 Your userID and API token are available on the [Habitica options/setting/api

--- a/habitica/core.py
+++ b/habitica/core.py
@@ -23,7 +23,6 @@ from . import api
 
 
 VERSION = 'habitica version 0.0.10'
-CONFIG_FILE = '~/.habiticarc'
 CACHE_FILE = '~/.habitica.cache'
 TASK_VALUE_BASE = 0.9747  # http://habitica.wikia.com/wiki/Task_Value
 HABITICA_REQUEST_WAIT_TIME = 0.5  # time to pause between concurrent requests
@@ -33,19 +32,11 @@ PRIORITY = {'easy': 1,
             'hard': 2}  # https://trello.com/c/4C8w1z5h/17-task-difficulty-settings-v2-priority-multiplier
 
 
-def load_config(fname):
-    config = None
-    try:
-        config = json.load(open(os.path.expanduser(fname), 'r'))
-    except IOError as err:
-        raise IOError('No config file at %s' % fname)
-    except ValueError as err:
-        print('Malformed config file at %s\n' % fname)
-        raise ValueError(err.msg)
-    except KeyError as err:
-        raise KeyError('Missing config key,value in %s\n' % fname)
-    return config
-
+def load_netrc:
+    host='habitica.com'
+    accts = netrc.netrc()
+    authn = accts.authenticators(host)
+    return dict( 'x-api-user': authn[0], 'x-api-key': authn[2])
 
 def clear_cache():
     """delete the cache file CACHE_FILE."""
@@ -130,10 +121,7 @@ def cli():
     """
 
     # load config and set auth
-    config = load_config(CONFIG_FILE)
-    authkeys = ['x-api-user', 'x-api-key']
-    auth = dict([(k, config[k]) for k in authkeys])
-    #auth = dict([(k, config[k]) for k in authkeys if k in config])
+    auth = load_netrc()
 
     # set up args
     args = docopt(cli.__doc__, version=VERSION)

--- a/habiticarc.sample.json
+++ b/habiticarc.sample.json
@@ -1,4 +1,0 @@
-{
-    "x-api-user": "USER_ID",
-    "x-api-key": "API_KEY"
-}

--- a/netrc.sample
+++ b/netrc.sample
@@ -1,0 +1,3 @@
+machine habitica.com
+    login USER_ID
+    password API_KEY


### PR DESCRIPTION
This is an aggressive implementation of #8, wholly removing `~/.habiticarc` support, and not really adding proper error handling.

A real implementation would:
- [ ] support `~/.netrc` and `~/.habiticarc`
- [ ] document precedence between them
- [ ] pull the `machine` name from a variable to support local habitica instances
- [ ] raise a friendly error message if neither the `default` nor `habitica.com` authenticator is found
- [ ] raise a friendly error message if `login` or `password` is `None`
