### PR TITLE
Force unix line endings from windows devs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
I'm on windows and I don't want to push files that use windows line
endings so I'm adding this setting. I have other repositories that
demand windows line endings so it's best to specify in the repo and not
rely on user settings.
