### PR TITLE
use string write to make cache work

### DIFF
--- a/habitica/core.py
+++ b/habitica/core.py
@@ -89,7 +89,7 @@ def load_cache(configfile):
     defaults = {'quest_key': '',
                 'quest_s': 'Not currently on a quest'}
 
-    cache = configparser.SafeConfigParser(defaults)
+    cache = configparser.ConfigParser(defaults)
     cache.read(configfile)
 
     if not cache.has_section(SECTION_CACHE_QUEST):
@@ -106,7 +106,7 @@ def update_quest_cache(configfile, **kwargs):
     for key, val in kwargs.items():
         cache.set(SECTION_CACHE_QUEST, key, val)
 
-    with open(configfile, 'wb') as f:
+    with open(configfile, 'w') as f:
         cache.write(f)
 
     cache.read(configfile)


### PR DESCRIPTION
When ~/.config/habitica/cache.cfg doesn't exist, as in a fresh install, the cache returned from `load_cache` is a string object, but `update_quest_cache` expects to write bytes, `'wb'`.

``` python
Traceback (most recent call last):
  File "/home/d9w/.venvs/test/bin/habitica", line 13, in <module>
    habitica.cli()
  File "/home/d9w/.venvs/test/lib/python3.5/site-packages/habitica/core.py", line 325, in cli
    quest_title=str(quest_title))
  File "/home/d9w/.venvs/test/lib/python3.5/site-packages/habitica/core.py", line 110, in update_quest_cache
    cache.write(f)
  File "/usr/lib64/python3.5/configparser.py", line 913, in write
    self._defaults.items(), d)
  File "/usr/lib64/python3.5/configparser.py", line 920, in _write_section
    fp.write("[{}]\n".format(section_name))
TypeError: a bytes-like object is required, not 'str'
```

Steps to reproduce:
- remove ~/.config/habitica/cache.cfg
- run `habitica status`

This fixes that by using string `'w'`. I also got deprication warnings for `SafeConfigParser` to change to `ConfigParser`, so that's lumped in here.
