### PR TITLE
Add contributing doc and link to the wikia page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# How to contribute
+
+Clone, contribute, create a pull request, and nudge Phil to review it.
+
+# Releases
+
+Remember to update the [Habitica command line tool](http://habitica.wikia.com/wiki/Habitica_Command_Line_Tool) page on the Habitica wikia with the latest release number and date.


### PR DESCRIPTION
Hey Phil,

I updated the wikia page because it was still showing that this project wasn't working with version 3 of the API. Then I figured it'd be good to have a reminder in the repo to do this.

Obviously go ahead and rewrite or remove the "How to contribute" section to your liking.

Thanks,

Robert