### PR TITLE
Fix party quest err when user without a party run `habitica status` command

### DIFF
--- a/habitica/api.py
+++ b/habitica/api.py
@@ -80,5 +80,7 @@ class Habitica(object):
         # print(res.url)  # debug...
         if res.status_code == requests.codes.ok:
             return res.json()["data"]
+        elif res.status_code == 404:
+            return None
         else:
             res.raise_for_status()

--- a/habitica/core.py
+++ b/habitica/core.py
@@ -45,6 +45,8 @@ CACHE_CONF = os.path.expanduser('~') + '/.config/habitica/cache.cfg'
 SECTION_CACHE_QUEST = 'Quest'
 checklists_on = False
 
+DEFAULT_QUEST = 'Not currently on a quest'
+
 
 def load_auth(configfile):
     """Get authentication data from the AUTH_CONF file."""
@@ -287,7 +289,7 @@ def cli():
         # doesn't make this stat particularly easy to grab...).
         # because hitting /content downloads a crapload of stuff, we
         # cache info about the current quest in cache.
-        quest = 'Not currently on a quest'
+        quest = DEFAULT_QUEST
         if (party is not None and
                 party.get('quest', '') and
                 party.get('quest').get('active')):
@@ -355,7 +357,8 @@ def cli():
         print('%s %s' % ('Mana:'.rjust(len_ljust, ' '), mana))
         print('%s %s' % ('Pet:'.rjust(len_ljust, ' '), pet))
         print('%s %s' % ('Mount:'.rjust(len_ljust, ' '), mount))
-        print('%s %s' % ('Quest:'.rjust(len_ljust, ' '), quest))
+        print('%s %s' % ('Quest:'.rjust(len_ljust, ' '), quest) 
+                if quest != DEFAULT_QUEST else '')
 
     # GET/POST habits
     elif args['<command>'] == 'habits':


### PR DESCRIPTION
Hey there,
When I installed and run `habitica status`, it returns

![image](https://cloud.githubusercontent.com/assets/4531922/20235836/26fb31f6-a8d9-11e6-812a-5601163a982f.png)

And found same issue fix https://github.com/philadams/habitica/issues/38

So I just dig in and try to fix it.
Also hide the quest progress print when not currently on a quest for better UX.
Here is my result:

![image](https://cloud.githubusercontent.com/assets/4531922/20235842/57eb9440-a8d9-11e6-82f4-35b0d578e440.png)

@philadams 
Please review, thanks.
😃


