### PR TITLE
fix encoding to utf-8 twice

### DIFF
--- a/habitica/core.py
+++ b/habitica/core.py
@@ -162,7 +162,7 @@ def print_task_list(tasks):
         completed = 'x' if task['completed'] else ' '
         task_line = '[%s] %s %s' % (completed,
                                     i + 1,
-                                    task['text'].encode('utf8'))
+                                    task['text'])
         checklist_available = cl_item_count(task) > 0
         if checklist_available:
             task_line += ' (%s/%s)' % (str(cl_done_count(task)),

--- a/habitica/core.py
+++ b/habitica/core.py
@@ -172,7 +172,7 @@ def print_task_list(tasks):
             for c, check in enumerate(task['checklist']):
                 completed = 'x' if check['completed'] else ' '
                 print('    [%s] %s' % (completed,
-                                       check['text'].encode('utf8')))
+                                       check['text']))
 
 
 def qualitative_task_score_from_value(value):


### PR DESCRIPTION
with this fix I'm able to print non-ascii strings as utf-8 strings, not as bytes representation:
like `купить`, not `b'\xd0\xba\xd1\x83\xd0\xbf...`