### PR TITLE
Fix party reporting

### DIFF
--- a/habitica/core.py
+++ b/habitica/core.py
@@ -296,7 +296,7 @@ def cli():
         # if in a party, grab party info
         if group:
             party_id = group[0]['id']
-            party_title = group[0]['name']
+            party = group[0]['name']
 
             # if on a quest with the party, grab quest info
             quest_data = getattr(hbt.groups, party_id)()['quest']
@@ -360,7 +360,8 @@ def cli():
         mount = items.get('currentMount', '')
         if not mount:
             mount = DEFAULT_MOUNT
-        summary_items = ('health', 'xp', 'mana', 'quest', 'pet', 'mount')
+        summary_items = ('health', 'xp', 'mana', 'pet', 'mount', 'party',
+                         'quest')
         len_ljust = max(map(len, summary_items)) + 1
         print('-' * len(title))
         print(title)


### PR DESCRIPTION
Party was always reported as default (no party), because the party name was getting put into party_title, which was never referenced. Changing party_title to be "party" as used in the rest of the code.