### PR TITLE
Fixed wrong wording in --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Via `habitica --help`:
       --version         Show version
       --difficulty=<d>  (easy | medium | hard) [default: easy]
       --verbose         Show some logging information
-      --debug           Some all logging information
+      --debug           Show all logging information
       -c --checklists   Toggle displaying checklists on or off
 
     The habitica commands are:

--- a/habitica/core.py
+++ b/habitica/core.py
@@ -215,7 +215,7 @@ def cli():
       --version         Show version
       --difficulty=<d>  (easy | medium | hard) [default: easy]
       --verbose         Show some logging information
-      --debug           Some all logging information
+      --debug           Show all logging information
       -c --checklists   Toggle displaying checklists on or off
 
     The habitica commands are:


### PR DESCRIPTION
Just changed "Some all" into "Show all", as it's supposed to be.