### PR TITLE
Accept HTTP status code 201

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,5 +8,6 @@ Thank you! In alphabetical order. [Full list at
 - [josephholsten](https://github.com/josephholsten)
 - [kurohai](https://github.com/kurohai)
 - [Lertsenem](https://github.com/Lertsenem)
+- [radeklat](https://github.com/radeklat)
 - [mohsend](https://github.com/mohsend)
 - [robertpateii](https://github.com/robertpateii)

--- a/habitica/api.py
+++ b/habitica/api.py
@@ -15,6 +15,7 @@ import requests
 
 API_URI_BASE = 'api/v3'
 API_CONTENT_TYPE = 'application/json'
+SUCCESS_CODES = frozenset([requests.codes.ok, requests.codes.created])
 
 
 class Habitica(object):
@@ -78,7 +79,7 @@ class Habitica(object):
                                             params=kwargs)
 
         # print(res.url)  # debug...
-        if res.status_code == requests.codes.ok:
+        if res.status_code in SUCCESS_CODES:
             return res.json()["data"]
         else:
             res.raise_for_status()


### PR DESCRIPTION
In create habitica endpoints, HTTP status code is 201, not 200. In these cases, data is not returned back from the library. Discovered and fix tested on https://habitica.com/apidoc/#api-Task-ScoreTask